### PR TITLE
various bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ There are a few things that need to be set up if you are interested in running t
 
 ### Email Account Setup
 
-I recommend creating a dedicated Google account for the purpose of sending out this report, as you will have to store your password in the secrets.py configuration file.
+I recommend creating a dedicated Google account for the purpose of sending out this report, as you will have to store your password in the `secrets.py` configuration file.
 
 You will also need to add this account to your club website, so that it is able to send out an email to any of the club email addresses. Make sure to opt-in after adding the rolemaster account to the club site.
 
-The account will need to have "Less Secure App Access" enabled. This can be done from the Google Account settings under the Security section.
+The account will need to have 2-Step Verification enabled. After doing this, you will need to set up an App Password. Both of these steps can be done in the Google Account settings under the Security section.
+
+After this is done, make sure to put the App Password, not the account password into `secrets.py`.
 
 ### Configuration
 
@@ -72,7 +74,9 @@ The account will need to have "Less Secure App Access" enabled. This can be done
   - `SUPPORT_EMAIL` with the email of the member who is managing the report, so other members can reach out with any questions/comments/etc
   - `AGENDA_LINK` with the link to the FTH agenda page (i.e. https://yourClubNameHere.toastmastersclubs.org/agenda.html)
 
-In addition to the configuration above, you can add or remove any custom roles in the config.py `ROLES` list. For example, my club also has a "Guest Ambassador" role for being in charge of welcoming guests to the meeting. Any additional custom roles that are added must also be added to the agendas, so that they are present in the downloaded Member Role Report.
+In addition to the configuration above, you can add or remove any custom roles in the `config.py` `ROLES` list. For example, my club also has a "Guest Ambassador" role for being in charge of welcoming guests to the meeting. Any additional custom roles that are added must also be added to the agendas, so that they are present in the downloaded Member Role Report.
+
+`config.py` is also where you can enable or disable the `tt.txt` file for tracking Table Topics speakers.
 
 ### Input Data
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You will also need to add this account to your club website, so that it is able 
 
 The account will need to have 2-Step Verification enabled. After doing this, you will need to set up an App Password. Both of these steps can be done in the Google Account settings under the Security section.
 
-After this is done, make sure to put the App Password, not the account password into `secrets.py`.
+After this is done, make sure to put the App Password, not the account password, into `secrets.py`.
 
 ### Configuration
 

--- a/calc.py
+++ b/calc.py
@@ -167,19 +167,11 @@ class RolemasterCalculator:
             elif role.find("Evaluator #") != -1:
                 role = "Evaluator"
 
-            # Do not track Presiding Officer
-            elif role == "Presiding Officer":
-                continue
-
             # Contest roles have some special rules
 
             # Contest timers can be counted against the Timer role
             elif role.find("Timer #") != -1:
                 role = "Timer"
-
-            # Chief Judge and Ballot Counters are not counted
-            elif role.find("Chief Judge") != -1 or role.find("Ballot Counter") != -1:
-                continue
 
             # Contest Chair can be counted as Toastmaster
             elif role.find("Contest Chair") != -1:

--- a/calc.py
+++ b/calc.py
@@ -12,8 +12,8 @@ class RolemasterCalculator:
     # Raw contents of the Member Role Report HTML file
     role_report = ''
 
-    # Raw contents of the Table Topics file
-    table_topics = ''
+    # Raw contents of the Table Topics file, as a list of lines
+    table_topics = []
 
     # Stores every role taken for each meeting for each member
     memberRoles = {}
@@ -167,10 +167,6 @@ class RolemasterCalculator:
             elif role.find("Evaluator #") != -1:
                 role = "Evaluator"
 
-            # Change "Table Topics" to "Table Topics Master" to not confuse with Table Topics participant
-            elif role == "Table Topics":
-                role = "Table Topics Master"
-
             # Do not track Presiding Officer
             elif role == "Presiding Officer":
                 continue
@@ -200,6 +196,10 @@ class RolemasterCalculator:
 
             # TODO: what about Table Topics Contestants?
 
+            # Skip the role if it's not in the configured list
+            if role not in config.ROLES:
+                continue
+
             # Initialize the role list for this meeting date for this member, if it does not exist
             if self.memberRoles[name].get(date) is None:
                 self.memberRoles[name][date] = []
@@ -217,8 +217,7 @@ class RolemasterCalculator:
         """
 
         # Get all of the Table Topics lines and loop through them
-        tts = reports.getTableTopics()
-        for tt in tts:
+        for tt in self.table_topics:
 
             # Trim off trailing newline character
             tt = tt.replace('\n', '')
@@ -240,8 +239,8 @@ class RolemasterCalculator:
             if self.memberRoles[name].get(date) is None:
                 self.memberRoles[name][date] = []
 
-            # Add Table Topics to the role list.
-            self.memberRoles[name][date].append("Table Topics")
+            # Add Table Topics speaker to the role list.
+            self.memberRoles[name][date].append(config.TT_DISPLAY_ROLE)
 
     def __addMissingRoles(self):
         """

--- a/config.py
+++ b/config.py
@@ -1,10 +1,16 @@
 # Directory that the Member Role Reports are stored in
 REPORTS_DIR = "./reports"
 
+# Boolean indicating if Table Topics speakers are used for the award
+TT_IS_USED = True
+
+# Display name for the Table Topics speaker role
+TT_DISPLAY_ROLE = "Table Topics Speaker"
+
 # Directory that the tt.txt file is stored in
 TT_DIR = "./tt"
 
-# List of roles to count for the award
+# List of agenda roles to count for the award
 ROLES = [
     "Toastmaster",
     "Humorist",
@@ -12,12 +18,15 @@ ROLES = [
     "Ah Counter",
     "Timer",
     "Speaker",
-    "Table Topics Master",
     "General Evaluator",
     "Evaluator",
     "Table Topics",
     "Guest Ambassador"
 ]
+
+# If Table Topics speakers is enabled/required, adds it to the role list
+if (TT_IS_USED):
+    ROLES.append(TT_DISPLAY_ROLE)
 
 # Padding of various HTML elements in the generated email
 PADDING = '10px'

--- a/reports.py
+++ b/reports.py
@@ -37,8 +37,12 @@ def getReportSubjectLine():
 
 def getTableTopics():
     """
-    Get the contents of the tt/tt.txt file, which contains historical TT data.
+    Get the contents of the tt/tt.txt file, which contains historical TT data,
+    but only if TT_IS_USED is set to True.
     """
+    if config.TT_IS_USED is False:
+        return []
+
     with open(f'{config.TT_DIR}/tt.txt') as f:
         lines = f.readlines()
         return lines


### PR DESCRIPTION
- adding bool toggle, `TT_IS_USED` for `tt.txt` functionality
- adding config value for Table Topics speaker display name (`TT_DISPLAY_ROLE`)
  - removing "Table Topics" --> "Table Topics Master" logic
  - will default to "Table Topics" for the TTM and "Table Topics Speaker" for the speakers
  - **this is relevantfor TWF, since it means we are "reversing" how we display the Table Topics roles**
  - also removing other edge cases that are now covered by the roles list
- updating README w/ 2FA / App Password info
- skipping role in HTML report if it wasn't included in the `config.py` roles list